### PR TITLE
Check file has a parent directory before creating it

### DIFF
--- a/src/main/java/com/huawei/yang/comparator/YangComparator.java
+++ b/src/main/java/com/huawei/yang/comparator/YangComparator.java
@@ -567,7 +567,7 @@ public class YangComparator {
         String output = args[outBegin + 1];
         File outputFile = new File(output);
         if(!outputFile.exists()){
-            if(!outputFile.getParentFile().exists()){
+            if(outputFile.getParentFile() != null && !outputFile.getParentFile().exists()){
                 outputFile.getParentFile().mkdirs();
             }
             outputFile.createNewFile();


### PR DESCRIPTION
outputFile.getParentFile will return null if the output is defined without a parent directory, for example `-o out.xml`.