### PR TITLE
Fix bug in getCompatibilityRule

### DIFF
--- a/src/main/java/com/huawei/yang/comparator/CompatibilityRules.java
+++ b/src/main/java/com/huawei/yang/comparator/CompatibilityRules.java
@@ -33,7 +33,7 @@ public class CompatibilityRules {
 
     public CompatibilityRule getCompatibilityRule(String ruleId){
         for(CompatibilityRule rule:compatibilityRules){
-            if(rule.getRuleId().equals(rule)){
+            if(rule.getRuleId().equals(ruleId)){
                 return rule;
             }
         }


### PR DESCRIPTION
compare `rule.getRuleId` to the given `ruleId`, not to the `rule` itself.